### PR TITLE
Use the more reliable request.el 

### DIFF
--- a/matrix-api-r0.3.0.el
+++ b/matrix-api-r0.3.0.el
@@ -360,24 +360,24 @@ MESSAGE and ARGS should be a string and list of strings for
     (apply #'matrix-log args)))
 
 (defun matrix-get (&rest args)
-  "Call `matrix-request' with ARGS for a \"GET\" request."
+  "Call `matrix-request-request' with ARGS for a \"GET\" request."
   (declare (indent defun))
   (apply #'matrix-request-request args ))
 
 (defun matrix-post (&rest args)
-  "Call `matrix-request' with ARGS for a \"POST\" request."
+  "Call `matrix-request-request' with ARGS for a \"POST\" request."
   (declare (indent defun))
   (nconc args (list :method 'post))
   (apply #'matrix-request-request args))
 
 (defun matrix-put (&rest args)
-  "Call `matrix-request' with ARGS for a \"PUT\" request."
+  "Call `matrix-request-request' with ARGS for a \"PUT\" request."
   (declare (indent defun))
   (nconc args (list :method 'put))
   (apply #'matrix-request-request args))
 
 (defun matrix-delete (&rest args)
-  "Call `matrix-request' with ARGS for a \"DELETE\" request."
+  "Call `matrix-request-request' with ARGS for a \"DELETE\" request."
   (declare (indent defun))
   (nconc args (list :method 'delete))
   (apply #'matrix-request-request args))

--- a/matrix-api-r0.3.0.el
+++ b/matrix-api-r0.3.0.el
@@ -362,25 +362,25 @@ MESSAGE and ARGS should be a string and list of strings for
 (defun matrix-get (&rest args)
   "Call `matrix-request' with ARGS for a \"GET\" request."
   (declare (indent defun))
-  (apply #'matrix-request args ))
+  (apply #'matrix-request-request args ))
 
 (defun matrix-post (&rest args)
   "Call `matrix-request' with ARGS for a \"POST\" request."
   (declare (indent defun))
   (nconc args (list :method 'post))
-  (apply #'matrix-request args))
+  (apply #'matrix-request-request args))
 
 (defun matrix-put (&rest args)
   "Call `matrix-request' with ARGS for a \"PUT\" request."
   (declare (indent defun))
   (nconc args (list :method 'put))
-  (apply #'matrix-request args))
+  (apply #'matrix-request-request args))
 
 (defun matrix-delete (&rest args)
   "Call `matrix-request' with ARGS for a \"DELETE\" request."
   (declare (indent defun))
   (nconc args (list :method 'delete))
-  (apply #'matrix-request args))
+  (apply #'matrix-request-request args))
 
 (defun matrix-lookup (name)
   "Return host for Matrix server for domain NAME.


### PR DESCRIPTION
update matrix-get, matrix-delete, matrix-put and matrix-post to use matrix-request-request which uses curl backend if installed. this has a significant improvement to the overall speed, and prevents emacs from hanging or crashing due to unreliable asynchronous calls, i tested this and it didn't hang once until now. you can test this by installing https://github.com/saadnpq/matrix-client.el 