### PR TITLE
Allow an URI scheme to be present in the server name

### DIFF
--- a/matrix-api-r0.3.0.el
+++ b/matrix-api-r0.3.0.el
@@ -141,7 +141,10 @@ automatically, and other keys are allowed."
                                                   user)))
            :documentation "FQDN of server, e.g. \"matrix.org\" for the official homeserver.  Derived automatically when not explicitly set.")
    (api-url-prefix :type string
-                   :instance-initform (concat "https://" server "/_matrix/client/r0/")
+                   :instance-initform (concat (if (string-match-p (rx bos "http" (opt "s") "://")
+                                                                  server)
+                                                  "" "https://")
+                                              server "/_matrix/client/r0/")
                    :documentation "URL prefix for API requests.  Derived automatically from server-name and built-in API version.")
    (device-id :initarg :device-id
               :initform (md5 (concat "matrix-client.el" (system-name)))

--- a/matrix-bufler.el
+++ b/matrix-bufler.el
@@ -112,8 +112,10 @@
           (matrix-client-room-avatar-in-buffer-name-size (* 2 (default-font-width))))
       (save-window-excursion
         (bufler))
-      (display-buffer-in-side-window (get-buffer "*Bufler*")
-                                     '((side . right))))))
+      (when-let* ((window (display-buffer-in-side-window (get-buffer "*Bufler*")
+                                                         '((side . right)))))
+        (set-window-parameter window 'delete-window #'ignore)
+        (select-window window)))))
 
 ;;;; Footer
 


### PR DESCRIPTION
If the scheme is specified in the server’s URI (e.g. `http://localhost:8009` which might be common if you use Pantalaimon), we will use that.  Only if the scheme is not set we fall back to the default `https://`.